### PR TITLE
keyframes fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,8 @@ module.exports = postcss.plugin( 'postcss-editor-styles', options => {
 	return root => {
 		root.walkRules( rule => {
 			rule.selectors = rule.selectors.map( selector => {
-				if (rule.parent.name === 'keyframes') {
-					return selector
+				if ( rule.parent.type === 'atrule' && rule.parent.name === 'keyframes' ) {
+					return selector;
 				}
 
 				if ( -1 !== opts.remove.indexOf( selector ) ) {

--- a/index.js
+++ b/index.js
@@ -37,6 +37,10 @@ module.exports = postcss.plugin( 'postcss-editor-styles', options => {
 	return root => {
 		root.walkRules( rule => {
 			rule.selectors = rule.selectors.map( selector => {
+				if (rule.parent.name === 'keyframes') {
+					return selector
+				}
+
 				if ( -1 !== opts.remove.indexOf( selector ) ) {
 					return rule.remove();
 				}

--- a/test/basic.css
+++ b/test/basic.css
@@ -44,4 +44,13 @@ button {
     box-sizing: border-box;
 }
 
+@keyframes test {
+	0% {
+		transform: rotate(0deg);
+	}
+	100% {
+		transform: rotate(360deg);
+	}
+}
+
 

--- a/test/basic.css
+++ b/test/basic.css
@@ -44,7 +44,7 @@ button {
     box-sizing: border-box;
 }
 
-@keyframes test {
+@keyframes spinner {
 	0% {
 		transform: rotate(0deg);
 	}
@@ -52,5 +52,3 @@ button {
 		transform: rotate(360deg);
 	}
 }
-
-

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -40,4 +40,11 @@
     box-sizing: border-box;
 }
 
-
+@keyframes spinner {
+	0% {
+		transform: rotate(0deg);
+	}
+	100% {
+		transform: rotate(360deg);
+	}
+}


### PR DESCRIPTION
I had the problem that the steps inside `@keyframes` are prefixed as well.
```CSS
@keyframes spinner {
    0% { transform: rotate(0deg); }
    100% { transform: rotate(360deg); }
}
```
==>
```CSS
@keyframes spinner {
    .editor-styles-wrapper 0% { transform: rotate(0deg); }
    .editor-styles-wrapper 100% { transform: rotate(360deg); }
}
```
Which is obviously broken. So I added a keyframes-check to the `rule.selectors.map`.