### PR TITLE
[BUGFIX]: Support selectors that are substring of provided scope

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -13,5 +13,12 @@ module.exports = {
 	},
 	tags: {
 		message: 'supports tags usage'
+	},
+	substring: {
+		message: 'supports selectors that are a substring of scopeTo',
+		options: {
+			scopeTo: `.component-library`,
+			tags: [],
+		}
 	}
 };

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = postcss.plugin('postcss-editor-styles', options => {
 					}`;
 				}
 
-				if (firstOrLastSelector(opts.scopeTo, selectArr)) {
+				if (firstOrLastSelector([opts.scopeTo], selectArr)) {
 					return selector;
 				}
 

--- a/test/substring.css
+++ b/test/substring.css
@@ -1,0 +1,19 @@
+h1 {
+  font-size: 2rem;
+}
+
+b {
+  font-weight: 600;
+}
+
+li {
+  padding-left: 4px;
+}
+
+button {
+  outline: none;
+}
+
+a {
+  text-decoration: none;
+}

--- a/test/substring.expect.css
+++ b/test/substring.expect.css
@@ -1,0 +1,19 @@
+.component-library h1 {
+  font-size: 2rem;
+}
+
+.component-library b {
+  font-weight: 600;
+}
+
+.component-library li {
+  padding-left: 4px;
+}
+
+.component-library button {
+  outline: none;
+}
+
+.component-library a {
+  text-decoration: none;
+}


### PR DESCRIPTION
Fixes a bug where scope was not getting applied to selectors that are a substring of the scope provided.
Ex - `scopeTo: .abcd` -> in this case, styles applied to `a` (anchor tag) and `b` (bold tag) won't have the `.abcd` scope since `a` and `b` are substrings of `abcd`